### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Requirements
 liblowladb is currently supported on iOS 6.0 and above. Versions for Android and Windows are planned.
-Note that the unit tests for liblowladb on iOS require XCode 6.
+Note that the unit tests for liblowladb on iOS require Xcode 6.
 
 ## Installation
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
